### PR TITLE
feat: implement rollup config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,32 @@ Need more evidence that Rollup and ES6 modules are awesome? See [rollup-comparis
 and [A better build system with Rollup](http://pouchdb.com/2016/01/13/pouchdb-5.2.0-a-better-build-system-with-rollup.html).
 
 Need to get started converting your CommonJS codebase into ES6? Try [cjs-to-es6](https://github.com/nolanlawson/cjs-to-es6).
+
+Customising rollup
+----
+
+Given a `rollup.config.js` like:
+
+```js
+module.exports = {
+  plugins: [
+    require('rollup-plugin-babel')({
+      exclude: 'node_modules/**'
+    })
+  ]
+}
+```
+
+Use it through the command line:
+
+    browserify -t [ rollupify --config rollup.config.js ] index.js > output.js
+
+Or in your `package.json`:
+
+```js
+"browserify": {
+  "transform": ["rollupify", {"config": "rollup.config.js"}]
+}
+```
+
+

--- a/index.js
+++ b/index.js
@@ -29,10 +29,16 @@ function rollupify(filename, opts) {
     var doSourceMap = opts.sourceMaps !== false;
 
     writeFile(tmpfile, source, 'utf8').then(function () {
-      return rollup.rollup({
+      var config = {};
+      if (opts.config) {
+        var configPath = /^\//.test(opts.config) ? opts.config : process.cwd() + '/' + opts.config;
+        config = require(configPath);
+      }
+
+      return rollup.rollup(Object.assign(config, {
         entry: tmpfile,
         sourceMap: doSourceMap ? 'inline' : false
-      })
+      }))
     }).then(function (bundle) {
       var generated = bundle.generate({format: 'cjs'});
       self.push(generated.code);

--- a/test/rollup-plugin-test.js
+++ b/test/rollup-plugin-test.js
@@ -1,0 +1,7 @@
+module.exports = {
+  transform: function(code) {
+    return {
+      code: "console.log('rollup-plugin-test')"
+    };
+  }
+}

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('./rollup-plugin-test')]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -32,9 +32,9 @@ describe('main test', function () {
     });
   }
 
-  function getBrowserifiedCode(path, opts) {
+  function getBrowserifiedCode(path, opts, transformOpts) {
     var b = browserify(require.resolve(path), opts)
-      .transform(transform).bundle();
+      .transform(transform, transformOpts).bundle();
     return stream2promise(b).then(function (buff) {
       var code = derequire(buff.toString('utf8'));
       return code;
@@ -106,6 +106,16 @@ describe('main test', function () {
       return execBrowserify(code)
     }).then(function (output) {
       assert.equal(output, '');
+    });
+  });
+
+  it('uses a custom config in rollup', function () {
+    return Promise.resolve().then(function () {
+      return getBrowserifiedCode('./test1', {}, {config: './test/rollup.config.js'});
+    }).then(function (code) {
+      return execBrowserify(code);
+    }).then(function (output) {
+      assert.equal(output, 'rollup-plugin-test');
     });
   });
 


### PR DESCRIPTION
Hey all,

Here's a solution to passing in options to rollup. At first I thought about adding specifics for the different options it supports but quickly it became clear that the easiest and most extensible way was to allow for any config that rollup supports to be imported from a file. So, given a `rollup.config.js` like:

``` js
module.exports = {
  plugins: [
    require('rollup-plugin-babel')({
      exclude: 'node_modules/**'
    })
  ]
}
```

Use it like:

```
browserify -t [ rollupify --config rollup.config.js ] index.js > output.js
```

Would love to hear your thoughts on this :)

Fixes #3.
