### PR TITLE
feat: cache rollup's bundle to massively speed-up watchify bundles

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var unlink = denodeify(fs.unlink);
 var path = require('path');
 var noop = require('noop-fn');
 
+var cache;
+
 function rollupify(filename, opts) {
   if (!/\.(?:js|es|es6|jsx)$/.test(filename)) {
     return through();
@@ -39,11 +41,13 @@ function rollupify(filename, opts) {
       }
 
       return rollup.rollup(Object.assign(config, {
+        cache: cache,
         entry: tmpfile,
         sourceMap: doSourceMap ? 'inline' : false
       }))
     }).then(function (bundle) {
       var generated = bundle.generate({format: 'cjs'});
+      cache = bundle;
       self.push(generated.code);
       self.push(null);
 


### PR DESCRIPTION
Simple change, huuuge impact :)

Random numbers from a project I'm working on now:

Before this:

```
# cold load
651137 bytes written (4.87 seconds)

# subsequent bundles
651270 bytes written (2.55 seconds)
```

After the patch:

```
# cold load
651137 bytes written (4.87 seconds)

# subsequent bundles
651270 bytes written (0.53 seconds)
```

It's like 5 times faster already :)
