### PR TITLE
add .ts and .tsx as valid extension for rollup

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var noop = require('noop-fn');
 var cache;
 
 function rollupify(filename, opts) {
-  if (!/\.(?:js|es|es6|jsx)$/.test(filename)) {
+  if (!/\.(?:js|es|es6|jsx|ts|tsx)$/.test(filename)) {
     return through();
   }
 


### PR DESCRIPTION
Allow to use rollupify with typescript, see:
- https://www.npmjs.com/package/tsify
- https://github.com/rollup/rollup-plugin-typescript

It just adds .ts and .tsx as valid extensions.
