### PR TITLE
chore: upgrade rollup to ^0.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "denodeify": "^1.2.1",
     "noop-fn": "^1.0.0",
-    "rollup": "^0.41.1",
+    "rollup": "^0.43.0",
     "through2": "^2.0.1"
   },
   "repository": {


### PR DESCRIPTION
This is due to `rollup` having a major at `0`, we're not getting the `0.43` update otherwise.