### PR TITLE
fix: ensure file exists before before telling browserify about it

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function rollupify(filename, opts) {
 
         bundle.modules.forEach(function(module) {
           var file = module.id;
-          if (!/\.tmp$/.test(file)) {
+          if (!/\.tmp$/.test(file) && fs.existsSync(file)) {
             self.emit('file', file)
           }
         });


### PR DESCRIPTION
There seems to be an issue with dependencies being reported as files like `babelHelpers` that creep up here. I don't know if there's a better solution but checking that the file exists seems like a good short-circuit for now. What do you think @nolanlawson? cc @amymc who spotted it first